### PR TITLE
Release 2019_03_28

### DIFF
--- a/src/pages/assessments/assessments.page.ts
+++ b/src/pages/assessments/assessments.page.ts
@@ -22,6 +22,7 @@ import { AssessmentsGroupPage } from './group/assessments-group.page'
 import { ItemsPopupPage } from './popup/items-popup.page';
 // import { TabsPage } from '../../pages/tabs/tabs.page';
 import { ActivitiesListPage } from '../activities/list/list.page';
+import { NotificationService } from '../../shared/notification/notification.service';
 
 @Component({
   selector: 'assessments-page',
@@ -67,7 +68,8 @@ export class AssessmentsPage {
     private gameService: GameService,
     private submissionService: SubmissionService,
     private translationService: TranslationService,
-    public events: Events
+    public events: Events,
+    private notificationService: NotificationService,
   ) {
     this.activity = this.navParams.get('activity');
     if (!this.activity) {
@@ -420,6 +422,12 @@ export class AssessmentsPage {
                     assessment_question_id: answ.assessment_question_id,
                     answer: answ.answer
                   }
+                } else {
+                  // return empty object to accommodate submission format accepted by server
+                  return {
+                    assessment_question_id: answ.assessment_question_id,
+                    answer: '',
+                  };
                 }
               })
             }));
@@ -430,14 +438,18 @@ export class AssessmentsPage {
         .forkJoin(tasks)
         .subscribe(
           (assessments: any) => {
-            loading.dismiss().then(_ => {
+            loading.dismiss().then(() => {
               this.allowSubmit = false;
               this.popupAfterSubmit();
             });
           },
           err => {
-            loading.dismiss().then(_ => {
-              console.log('err', err);
+            loading.dismiss().then(() => {
+              this.notificationService.alert({
+                title: 'Submission Failed.',
+                subTitle: err.msg,
+                buttons: ['Close']
+              });
             });
           }
         );


### PR DESCRIPTION
Changes
[PE-298] optional question unable to let empty

Description of changes
-----
before the changes, we pass `null` value as `AssessmentSubmissionAnswer` which it'll render PHP error as following (which we should fix this error at BE too!).
```
Notice (8): Undefined index: assessment_question_id [ROOTappROOTControllerROOTComponentROOTAssessmentComponent.php, line 170]
{"success":false,"status":"invalid_resource","msg":"One of the submission answers is missing question id!"}
```

What is the root cause?

```json
// it's safe from error, if a group filled with all optional question and if non of the question is left untouched
// but if either of the question is answered, both question will be submitted to API (even the other question isnt answered)

// if optional group has any one question answered, the other unanswered becomes `null` (this is the root cause)
"AssessmentSubmissionAnswer": [
  null,
  { "assessment_question_id": 20802, "answer": { ... } }
]
```

After the fixes:
```json
// unanswered question in proper format, so that BE wont return error
"AssessmentSubmissionAnswer": [
  { "assessment_question_id": 20803, "answer": '' }, 
  { "assessment_question_id": 20802, "answer": { ... } }
]
```